### PR TITLE
Ability to show menu-toggle on child pages as known in ionic 1.

### DIFF
--- a/ionic/components/menu/menu-toggle.ts
+++ b/ionic/components/menu/menu-toggle.ts
@@ -4,7 +4,7 @@ import {Ion} from '../ion';
 import {IonicApp} from '../app/app';
 import {ViewController} from '../nav/view-controller';
 import {Navbar} from '../nav-bar/nav-bar';
-
+import {Menu} from '../menu/menu';
 
 /**
 * TODO
@@ -21,14 +21,18 @@ import {Navbar} from '../nav-bar/nav-bar';
 })
 export class MenuToggle extends Ion {
 
+  private menu:Menu;
+
   constructor(
     app: IonicApp,
     elementRef: ElementRef,
+    menu: Menu,
     @Optional() viewCtrl: ViewController,
     @Optional() navbar: Navbar
   ) {
     super(elementRef, null);
     this.app = app;
+    this.menu = menu;
     this.viewCtrl = viewCtrl;
     this.withinNavbar = !!navbar;
   }
@@ -44,7 +48,7 @@ export class MenuToggle extends Ion {
 
   get isHidden() {
     if (this.withinNavbar && this.viewCtrl) {
-      return !this.viewCtrl.isRoot();
+      return !this.viewCtrl.isRoot() && !this.menu.isMenuWithBackViewsEnabled()
     }
     return false;
   }

--- a/ionic/components/menu/menu.ts
+++ b/ionic/components/menu/menu.ts
@@ -313,8 +313,8 @@ class MenuBackdrop {
    */
   constructor(@Host() menu: Menu, elementRef: ElementRef) {
     this.menu = menu;
-    //this.elementRef = elementRef;
-    //menu.backdrop = this;
+    this.elementRef = elementRef;
+    menu.backdrop = this;
   }
 
   /**

--- a/ionic/components/menu/menu.ts
+++ b/ionic/components/menu/menu.ts
@@ -53,7 +53,8 @@ import * as gestures from  './menu-gestures';
   ],
   defaultInputs: {
     'side': 'left',
-    'type': 'reveal'
+    'type': 'reveal',
+    'enableMenuWithBackViews': false
   },
   outputs: ['opening'],
   host: {
@@ -271,6 +272,14 @@ export class Menu extends Ion {
     return this.backdrop.elementRef.nativeElement;
   }
 
+  /**
+   * TODO
+   * @return {boolean}
+   */
+  isMenuWithBackViewsEnabled() {
+    return this.enableMenuWithBackViews;
+  }
+
   static register(name, cls) {
     menuTypes[name] = cls;
   }
@@ -304,8 +313,8 @@ class MenuBackdrop {
    */
   constructor(@Host() menu: Menu, elementRef: ElementRef) {
     this.menu = menu;
-    this.elementRef = elementRef;
-    menu.backdrop = this;
+    //this.elementRef = elementRef;
+    //menu.backdrop = this;
   }
 
   /**

--- a/ionic/components/menu/test/menu-toggle.spec.ts
+++ b/ionic/components/menu/test/menu-toggle.spec.ts
@@ -1,0 +1,73 @@
+// import {
+//   ddescribe,
+//   describe,
+//   xdescribe,
+//   it,
+//   iit,
+//   xit,
+//   expect,
+//   beforeEach,
+//   afterEach,
+//   AsyncTestCompleter,
+//   inject,
+//   beforeEachBindings
+// } from 'angular2/test';
+
+// import {Compiler} from 'angular2/angular2';
+
+import {
+    ViewController,
+    Navbar,
+    Menu,
+    MenuToggle
+} from 'ionic/ionic';
+
+
+export function run() {
+    describe("MenuToggle", () => {
+        let menu, menuToggle;
+
+        // beforeEach(inject([Compiler], compiler => {
+        beforeEach(() => {
+            menu = new Menu(null, null, null, null, null);
+            menuToggle = new MenuToggle(null, null, menu, ViewController, Navbar);
+        });
+
+        it('should exist', () => {
+            expect(menuToggle).not.toBeUndefined();
+        });
+
+        describe("isHidden", () => {
+
+            it('should not be hidden for root pages by default', function () {
+                ViewController.isRoot = () => {
+                    return true;
+                };
+                expect(menuToggle.isHidden).toBe(false);
+            });
+
+            it('should be hidden for child pages by default', function () {
+                ViewController.isRoot = () => {
+                    return false;
+                };
+                expect(menuToggle.isHidden).toBe(true);
+            });
+
+            it('should not be hidden for child pages when isMenuWithBackViewsEnabled is true', function () {
+                menu.enableMenuWithBackViews = true;
+                ViewController.isRoot = () => {
+                    return false;
+                };
+                expect(menuToggle.isHidden).toBe(false);
+            });
+
+            it('should be hidden for child pages when isMenuWithBackViewsEnabled is false', function () {
+                menu.enableMenuWithBackViews = false;
+                ViewController.isRoot = () => {
+                    return false;
+                };
+                expect(menuToggle.isHidden).toBe(true);
+            });
+        });
+    });
+}


### PR DESCRIPTION
In my Ionic2 App I would like to show the menu-toggle button also on child pages along with the back button. In Ionic 1 exists a flag to enable the button on child pages if needed by setting it on the side menu. In this Pull Request I tried to adapt this to Ionic2. 

The Pull Request includes small changes in menu component and some basic unit tests.