### PR TITLE
Fix: SqlStorage _getBackupLocation method argument

### DIFF
--- a/ionic/platform/storage/sql.ts
+++ b/ionic/platform/storage/sql.ts
@@ -50,7 +50,7 @@ export class SqlStorage extends StorageEngine {
 
 
     if(window.sqlitePlugin) {
-      let location = this._getBackupLocation(dbOptions);
+      let location = this._getBackupLocation(dbOptions.backupFlag);
 
       this._db = window.sqlitePlugin.openDatabase(util.extend({
         name: dbOptions.name,


### PR DESCRIPTION
_getBackupLocation(dbOptions.backupFlag) instead _getBackupLocation(dbOptions) because i get that error:
```
Error: Invalid backup flag: [object Object]
```