### PR TITLE
fix(statusbar): typo in the method

### DIFF
--- a/ionic/platform/statusbar/statusbar.ts
+++ b/ionic/platform/statusbar/statusbar.ts
@@ -84,7 +84,7 @@ export class StatusBar {
    */
   static setHexColor(hex) {
     this.ifPlugin(() => {
-      window.StatusBar.backgroundColorByHexName(hex);
+      window.StatusBar.backgroundColorByHexString(hex);
     });
   }
 


### PR DESCRIPTION
[backgroundColorByHexString](https://github.com/apache/cordova-plugin-statusbar/blob/master/www/statusbar.js#L73) instead backgroundColorByHexName because that method doesn't exists in cordova-plugin-statusbar