### PR TITLE
Floating Label Inputs with initial value

### DIFF
--- a/ionic/components/text-input/text-input.ts
+++ b/ionic/components/text-input/text-input.ts
@@ -374,7 +374,7 @@ export class TextInputElement {
   }
 
   onInit() {
-    this.wrapper.hasValue(this.value);
+    this.wrapper.hasValue(this.getNativeElement().value);
   }
 
   labelledBy(val) {


### PR DESCRIPTION
Floating Label Inputs don't behave correctly when they appear already filled with text: the label cover the input value.
The `has-value` class is not present as the `onInit` method always passes `undefined` to the `hasValue` method. It seems that the correct value can be accessed through the nativeElement