### PR TITLE
add an input swipeOpenEnabled to ion-menu

### DIFF
--- a/ionic/components/menu/menu.ts
+++ b/ionic/components/menu/menu.ts
@@ -95,7 +95,8 @@ import * as gestures from  './menu-gestures';
     'content',
     'id',
     'side',
-    'type'
+    'type',
+    'swipeOpenEnabled'
   ],
   defaultInputs: {
     'side': 'left',
@@ -156,7 +157,9 @@ export class Menu extends Ion {
       self.app.register(self.id, self);
     }
 
-    self._initGesture();
+    if ((self.swipeOpenEnabled || '').toString() !== 'false') {
+      self._initGesture();
+    }
     self._initType(self.type);
 
     self._cntEle.classList.add('menu-content');

--- a/ionic/components/menu/test/swipe-open-enabled/index.ts
+++ b/ionic/components/menu/test/swipe-open-enabled/index.ts
@@ -1,0 +1,27 @@
+import {App, IonicApp, Page} from 'ionic/ionic';
+
+
+@Page({templateUrl: 'page1.html'})
+class Page1 {}
+
+
+@App({
+  templateUrl: 'main.html'
+})
+class E2EApp {
+
+  constructor(app: IonicApp) {
+    this.app = app;
+    this.rootView = Page1;
+  }
+
+  openPage(menu, page) {
+    // close the menu when clicking a link from the menu
+    menu.close();
+
+    // Reset the content nav to have just this page
+    // we wouldn't want the back button to show in this scenario
+    let nav = this.app.getComponent('nav');
+    nav.setRoot(page.component);
+  }
+}

--- a/ionic/components/menu/test/swipe-open-enabled/main.html
+++ b/ionic/components/menu/test/swipe-open-enabled/main.html
@@ -1,0 +1,21 @@
+<ion-menu [content]="content" id="leftMenu" swipeOpenEnabled="false" side="left">
+
+  <ion-toolbar secondary>
+    <ion-title>Left Menu</ion-title>
+  </ion-toolbar>
+
+  <ion-content>
+
+    <ion-list>
+
+      <button ion-item menuToggle="leftMenu" detail-none>
+        Close Left Menu
+      </button>
+
+    </ion-list>
+  </ion-content>
+
+</ion-menu>
+
+
+<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>

--- a/ionic/components/menu/test/swipe-open-enabled/page1.html
+++ b/ionic/components/menu/test/swipe-open-enabled/page1.html
@@ -1,0 +1,29 @@
+
+<ion-navbar *navbar>
+
+  <button menuToggle="leftMenu">
+    <icon menu></icon>
+  </button>
+
+  <ion-title>
+    Reveal Menu
+  </ion-title>
+
+</ion-navbar>
+
+
+<ion-content #content padding>
+
+  <h3>Content</h3>
+
+  <p>
+    <button menuToggle="leftMenu">Toggle Left Menu</button>
+  </p>
+
+  <p>
+    <button menuToggle="rightMenu">Toggle Right Menu</button>
+  </p>
+
+  <f></f><f></f><f></f><f></f><f></f><f></f><f></f><f></f>
+
+</ion-content>


### PR DESCRIPTION
add an option to disable the side menu swipe globally

    <ion-menu [content]="content" swipeOpenEnabled="false">

note:
it disable the swipe gesture globally and no way to re-enable it using api. if you want to disable the swipe page by page, use the api: https://github.com/driftyco/ionic2/pull/784
