### PR TITLE
use Timeout to wait so that iDangerous Swiper can find the slide DOM

### DIFF
--- a/ionic/components/slides/slides.ts
+++ b/ionic/components/slides/slides.ts
@@ -161,9 +161,10 @@ export class Slides extends Ion {
       return this.options.onLazyImageReady && this.options.onLazyImageReady(swiper, slide, img);
     };
 
-    var swiper = new Swiper(this.getNativeElement().children[0], options);
-
-    this.slider = swiper;
+    setTimeout(() => {
+      var swiper = new Swiper(this.getNativeElement().children[0], options);
+      this.slider = swiper;
+    }, 100);
 
     /*
     * TODO: Finish this


### PR DESCRIPTION
delay the Swiper initialization with setTimeout, in order to let Swiper find the DOM created with ion-slide ngFor

trying to workaround the issue https://github.com/driftyco/ionic2/issues/751 that loop swiper is not working properly, so a setTimeout is used.
I think a better approach is some kind of lifecycle event from children components (i.e. ion-slide in this case), I am not familiar with Angular2 enough to use that approach.