### PR TITLE
fixing the button test case

### DIFF
--- a/ionic/components/button/test/button.spec.ts
+++ b/ionic/components/button/test/button.spec.ts
@@ -21,7 +21,7 @@ export function run() {
   }
 
   function hasClass(button, className) {
-    return button.elementRef.nativeElement.classList.contains(className);
+    return button._elementRef.nativeElement.classList.contains(className);
   }
 
   it('should ignore certain attributes', () => {


### PR DESCRIPTION
currently the npm test failed because of the button spec is checking on elementRef, which is now a private _elementRef