### PR TITLE
New compile flow uses app folder outside www

### DIFF
--- a/tooling/generate.js
+++ b/tooling/generate.js
@@ -68,7 +68,7 @@ Generate.generate = function generate(options) {
 Generate.defaultTemplates = function defaultTemplates(options) {
   var template = options.template ? options.template : 'page';
 
-  options.rootDirectory = options.rootDirectory || path.join('www', 'app');
+  options.rootDirectory = options.rootDirectory || path.join('app');
   var savePath = path.join(options.appDirectory, options.rootDirectory, options.fileName);
 
   var templates = Generate.loadGeneratorTemplates(path.join(__dirname, 'generators', options.template));


### PR DESCRIPTION
Since the update of 22/12/2015 ionic uses a new build system, it puts the app folder at the same tree level of www folder, as such the rootDirectory default should be only app.