### PR TITLE
Fixed small error in ion-sliding code example

### DIFF
--- a/ionic/components/item/item-sliding.ts
+++ b/ionic/components/item/item-sliding.ts
@@ -20,7 +20,7 @@ import {List} from '../list/list';
  *       <button (click)="favorite(item)">Favorite</button>
  *       <button (click)="share(item)">Share</button>
  *     </ion-item-options>
- *   </ion-item>
+ *   </ion-item-sliding>
  * </ion-list>
  * ```
  * @see {@link /docs/v2/components#lists List Component Docs}


### PR DESCRIPTION
Fixed typo in code example for ion-item-sliding component. 'ion-item-sliding' tag was being close incorrectly with 'ion-item' tag not 'ion-item-sliding'. Code example was throwing an error.