### PR TITLE
Android side menu backdrop does not leave

### DIFF
--- a/ionic/components/menu/menu-types.ts
+++ b/ionic/components/menu/menu-types.ts
@@ -185,7 +185,9 @@ class MenuOverlayType extends MenuType {
     this.open.add(menuOpen);
 
     let backdropOpen = new Animation(menu.getBackdropElement());
-    backdropOpen.fromTo(OPACITY, 0.01, backdropOpacity);
+    backdropOpen
+      .fromTo(OPACITY, 0.01, backdropOpacity)
+      .fromTo(TRANSLATE_X, '100%', '0%');
     this.open.add(backdropOpen);
 
     let menuClose = new Animation(menu.getMenuElement());
@@ -193,7 +195,9 @@ class MenuOverlayType extends MenuType {
     this.close.add(menuClose);
 
     let backdropClose = new Animation(menu.getBackdropElement());
-    backdropClose.fromTo(OPACITY, backdropOpacity, 0.01);
+    backdropClose
+      .fromTo(OPACITY, backdropOpacity, 0.01)
+      .fromTo(TRANSLATE_X, '0%', '100%');
     this.close.add(backdropClose);
   }
 }


### PR DESCRIPTION
When we use the side menu on Android, because the Animation system always adds a `translateZ(0)` property, the `ion-menu[type=overlay] .backdrop` > `transform: transate3d(9999px, ...)` property is overrided. This causes the backdrop to stay on top on the content (invisible as opacity is already animated to 0.01)