### PR TITLE
CSS: Remove unnecessary background definition

### DIFF
--- a/ionic/components/content/content.ios.scss
+++ b/ionic/components/content/content.ios.scss
@@ -14,7 +14,3 @@ ion-content {
   background: $outer-content-ios-background-color;
 }
 
-ion-nav.has-views,
-ion-tab.has-views {
-  background: #000;
-}


### PR DESCRIPTION
This is present in `content.ios.scss` but not `content.md.scss`, and it seems like it's no longer necessary.

It was introduced here: https://github.com/driftyco/ionic2/commit/2fe613580086039dc705a222fc7b7a87872516c8#diff-9fc06cce80fc98aeb457617120f24998R12

Can this be removed?