### PR TITLE
make the ion-menu threshold configurable

### DIFF
--- a/ionic/components/menu/menu-gestures.ts
+++ b/ionic/components/menu/menu-gestures.ts
@@ -9,7 +9,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
     super(targetEl, util.extend({
       direction: (menu.side === 'left' || menu.side === 'right') ? 'x' : 'y',
       edge: menu.side,
-      threshold: 75
+      threshold: menu.threshold || 75
     }, options));
 
     this.menu = menu;

--- a/ionic/components/menu/menu.ts
+++ b/ionic/components/menu/menu.ts
@@ -95,7 +95,8 @@ import * as gestures from  './menu-gestures';
     'content',
     'id',
     'side',
-    'type'
+    'type',
+    'threshold'
   ],
   defaultInputs: {
     'side': 'left',


### PR DESCRIPTION
```html
<ion-menu [content]="content" side="left" type="overlay" threshold='5'>
```

On the google map application, to open the menu you need to start your slide on the very edge of your screen.  
In case some apps want to replicate that behaviour, It could be a good idea to make the threshold configurable to overwrite the 75 by default.