### PR TITLE
Fix HammerJS Pan config bug

### DIFF
--- a/ionic/components/menu/menu-gestures.ts
+++ b/ionic/components/menu/menu-gestures.ts
@@ -9,7 +9,8 @@ export class MenuContentGesture extends SlideEdgeGesture {
     super(targetEl, util.extend({
       direction: (menu.side === 'left' || menu.side === 'right') ? 'x' : 'y',
       edge: menu.side,
-      threshold: menu.threshold || 75
+      threshold: 0,
+      maxEdgeStart: menu.maxEdgeStart || 75
     }, options));
 
     this.menu = menu;
@@ -53,7 +54,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
 export class TargetGesture extends MenuContentGesture {
   constructor(menu: Menu) {
     super(menu, menu.getNativeElement(), {
-      threshold: 0
+      maxEdgeStart: 0
     });
   }
 }

--- a/ionic/components/menu/menu.ts
+++ b/ionic/components/menu/menu.ts
@@ -96,7 +96,7 @@ import * as gestures from  './menu-gestures';
     'id',
     'side',
     'type',
-    'threshold'
+    'maxEdgeStart'
   ],
   defaultInputs: {
     'side': 'left',

--- a/ionic/gestures/gesture.ts
+++ b/ionic/gestures/gesture.ts
@@ -42,7 +42,7 @@ export class Gesture {
   }
 
   listen() {
-    this.hammertime = Hammer(this.element, this._options);
+    this.hammertime = new Hammer(this.element, this._options);
   }
 
   unlisten() {

--- a/ionic/gestures/slide-edge-gesture.ts
+++ b/ionic/gestures/slide-edge-gesture.ts
@@ -7,12 +7,12 @@ export class SlideEdgeGesture extends SlideGesture {
   constructor(element: Element, opts: Object = {}) {
     defaults(opts, {
       edge: 'left',
-      threshold: 50
+      maxEdgeStart: 50
     });
     super(element, opts);
     // Can check corners through use of eg 'left top'
     this.edges = opts.edge.split(' ');
-    this.threshold = opts.threshold;
+    this.maxEdgeStart = opts.maxEdgeStart;
   }
 
   canStart(ev) {
@@ -31,10 +31,10 @@ export class SlideEdgeGesture extends SlideGesture {
 
   _checkEdge(edge, pos) {
     switch (edge) {
-      case 'left': return pos.x <= this._d.left + this.threshold;
-      case 'right': return pos.x >= this._d.width - this.threshold;
-      case 'top': return pos.y <= this._d.top + this.threshold;
-      case 'bottom': return pos.y >= this._d.height - this.threshold;
+      case 'left': return pos.x <= this._d.left + this.maxEdgeStart;
+      case 'right': return pos.x >= this._d.width - this.maxEdgeStart;
+      case 'top': return pos.y <= this._d.top + this.maxEdgeStart;
+      case 'bottom': return pos.y >= this._d.height - this.maxEdgeStart;
     }
   }
 


### PR DESCRIPTION
###### Bug
Currently the DragGesture Class will overwrite the Pan config for every existing other DragGesture, here
```js
this.hammertime.get('pan').set(this._options);
```

this can be seen by debugging the value of options.threshold [here](https://github.com/driftyco/ionic2/blob/master/ionic/gestures/hammer.ts#L1660) in the PanRecognizer.
this value will always be the same, the last threshold created by DragGesture.

actually it can be seen as well because ion-nav threshold is set to [75 by default](https://github.com/driftyco/ionic2/blob/master/ionic/components/menu/menu-gestures.ts#L12) so HammerJS panstart event should not be fired when we pan less than 75px distance, but it its actually dragging instantly because its overwritten by the [TargetGesture threshold of 0](https://github.com/driftyco/ionic2/blob/master/ionic/components/menu/menu-gestures.ts#L56)

###### Fix

1. I replace hammer v2.0.4 by v2.0.6  and use the new operator in gesture.ts when creating hammer instance
2. threshold were actually used for two different purposes, checking the distance of the panstart from the edge and the hammer threshold, i split them into two distincts variable  
     __threshold__ which is the "hammer Minimal pan distance required before recognizing." (always set to 0 for the ion-menu because this is actually the case)  
    __maxEdgeStart__ which is the maximun distance of the panstart from the edge  
